### PR TITLE
Реализация сервиса Collector

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,24 +1,18 @@
-     # Ignore everything by default
-     **
+# Build artifacts
+**/target/
+**/build/
 
-     # Unignore root POM
-     !pom.xml
+# IDE and OS files
+.idea/
+*.iml
+.DS_Store
+*.log
 
-     # Unignore modules
-     !telemetry/
-     !infra/
-     !commerce/
+# VCS
+.git/
+.gitignore
 
-     # Reignore built files
-     **/target/
-     **/build/
-
-     # Unignore Maven files
-     !mvnw
-     !mvnw.cmd
-     !.mvn/
-
-     # Reignore IDE files
-     *.git/
-     *.idea/
-     *.iml
+# Maven wrapper
+mvnw
+mvnw.cmd
+.mvn/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,24 @@
+     # Ignore everything by default
+     **
+
+     # Unignore root POM
+     !pom.xml
+
+     # Unignore modules
+     !telemetry/
+     !infra/
+     !commerce/
+
+     # Reignore built files
+     **/target/
+     **/build/
+
+     # Unignore Maven files
+     !mvnw
+     !mvnw.cmd
+     !.mvn/
+
+     # Reignore IDE files
+     *.git/
+     *.idea/
+     *.iml

--- a/compose.yaml
+++ b/compose.yaml
@@ -54,7 +54,9 @@ services:
     init: true
 
   collector-service:
-      build: ./telemetry/collector
+      build:
+        context: .
+        dockerfile: ./telemetry/collector/Dockerfile
       container_name: collector-service
       depends_on:
         - kafka

--- a/compose.yaml
+++ b/compose.yaml
@@ -17,27 +17,11 @@ services:
       KAFKA_LISTENERS: 'PLAINTEXT://kafka:29092,CONTROLLER://kafka:29093,PLAINTEXT_HOST://0.0.0.0:9092'
       CLUSTER_ID: 'K0EA9p0yEe6MkAAAAkKsEg'
 
-  schema-registry:
-    image: confluentinc/cp-schema-registry:7.4.3
-    hostname: schema-registry
-    container_name: schema-registry
-    depends_on:
-      - kafka
-    ports:
-      - "8081:8081"
-    restart: unless-stopped
-    environment:
-      SCHEMA_REGISTRY_HOST_NAME: schema-registry
-      SCHEMA_REGISTRY_LISTENERS: 'http://0.0.0.0:8081'
-      SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: 'kafka:29092'
-
-
   kafka-init-topics:
     image: confluentinc/confluent-local:7.4.3
     container_name: kafka-init-topics
     depends_on:
       - kafka
-      - schema-registry
     command: "bash -c \
                 'echo Waiting for Kafka to be ready... && \
                 cub kafka-ready -b kafka:29092 1 20 && \
@@ -60,7 +44,6 @@ services:
       container_name: collector-service
       depends_on:
         - kafka
-        - schema-registry
       ports:
         - "8080:8080"
       restart: unless-stopped

--- a/compose.yaml
+++ b/compose.yaml
@@ -17,13 +17,32 @@ services:
       KAFKA_LISTENERS: 'PLAINTEXT://kafka:29092,CONTROLLER://kafka:29093,PLAINTEXT_HOST://0.0.0.0:9092'
       CLUSTER_ID: 'K0EA9p0yEe6MkAAAAkKsEg'
 
+  schema-registry:
+    image: confluentinc/cp-schema-registry:7.4.3
+    hostname: schema-registry
+    container_name: schema-registry
+    depends_on:
+      - kafka
+    ports:
+      - "8081:8081"
+    restart: unless-stopped
+    environment:
+      SCHEMA_REGISTRY_HOST_NAME: schema-registry
+      SCHEMA_REGISTRY_LISTENERS: 'http://0.0.0.0:8081'
+      SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: 'kafka:29092'
+
+
   kafka-init-topics:
     image: confluentinc/confluent-local:7.4.3
     container_name: kafka-init-topics
     depends_on:
       - kafka
+      - schema-registry
     command: "bash -c \
-                'kafka-topics --create --topic telemetry.sensors.v1 \
+                'echo Waiting for Kafka to be ready... && \
+                cub kafka-ready -b kafka:29092 1 20 && \
+                echo Kafka is ready! && \
+                kafka-topics --create --topic telemetry.sensors.v1 \
                              --partitions 1 --replication-factor 1 --if-not-exists \
                              --bootstrap-server kafka:29092 && \
                 kafka-topics --create --topic telemetry.snapshots.v1 \
@@ -33,3 +52,16 @@ services:
                              --partitions 1 --replication-factor 1 --if-not-exists \
                              --bootstrap-server kafka:29092'"
     init: true
+
+  collector-service:
+      build: ./telemetry/collector
+      container_name: collector-service
+      depends_on:
+        - kafka
+        - schema-registry
+      ports:
+        - "8080:8080"
+      restart: unless-stopped
+      environment:
+        KAFKA_BOOTSTRAP_SERVERS: kafka:29092
+        KAFKA_SCHEMA_REGISTRY_URL: http://schema-registry:8081

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.2</version>
+        <version>3.5.3</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -24,8 +24,8 @@
     <properties>
         <java.version>21</java.version>
 
-        <avro.version>1.11.3</avro.version>
-        <kafka-clients.version>3.6.1</kafka-clients.version>
+        <avro.version>1.12.0</avro.version>
+        <kafka-clients.version>4.0.0</kafka-clients.version>
         <springdoc-openapi-starter.version>2.6.0</springdoc-openapi-starter.version>
         <grpc-spring-boot-starter.version>3.1.0.RELEASE</grpc-spring-boot-starter.version>
         <protobuf.version>3.23.4</protobuf.version>

--- a/pom.xml
+++ b/pom.xml
@@ -31,20 +31,12 @@
         <protobuf.version>3.23.4</protobuf.version>
         <grpc.version>1.63.0</grpc.version>
         <mapstruct.version>1.6.3</mapstruct.version>
-        <kafka-avro-serializer.version>8.0.0</kafka-avro-serializer.version>
 
         <!--       Plugins       -->
         <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
         <avro-maven-plugin.version>${avro.version}</avro-maven-plugin.version>
         <protobuf-plugin.version>2.4.0</protobuf-plugin.version>
     </properties>
-
-    <repositories>
-        <repository>
-            <id>confluent</id>
-            <url>https://packages.confluent.io/maven/</url>
-        </repository>
-    </repositories>
 
     <dependencyManagement>
         <dependencies>
@@ -70,12 +62,6 @@
                 <groupId>org.mapstruct</groupId>
                 <artifactId>mapstruct</artifactId>
                 <version>${mapstruct.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>io.confluent</groupId>
-                <artifactId>kafka-avro-serializer</artifactId>
-                <version>${kafka-avro-serializer.version}</version>
             </dependency>
 
             <!--    GRPC dependencies management        -->

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
         <grpc-spring-boot-starter.version>3.1.0.RELEASE</grpc-spring-boot-starter.version>
         <protobuf.version>3.23.4</protobuf.version>
         <grpc.version>1.63.0</grpc.version>
+        <mapstruct.version>1.6.3</mapstruct.version>
 
         <!--       Plugins       -->
         <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
@@ -55,6 +56,12 @@
                 <groupId>org.springdoc</groupId>
                 <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
                 <version>${springdoc-openapi-starter.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.mapstruct</groupId>
+                <artifactId>mapstruct</artifactId>
+                <version>${mapstruct.version}</version>
             </dependency>
 
             <!--    GRPC dependencies management        -->

--- a/pom.xml
+++ b/pom.xml
@@ -31,12 +31,20 @@
         <protobuf.version>3.23.4</protobuf.version>
         <grpc.version>1.63.0</grpc.version>
         <mapstruct.version>1.6.3</mapstruct.version>
+        <kafka-avro-serializer.version>8.0.0</kafka-avro-serializer.version>
 
         <!--       Plugins       -->
         <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
         <avro-maven-plugin.version>${avro.version}</avro-maven-plugin.version>
         <protobuf-plugin.version>2.4.0</protobuf-plugin.version>
     </properties>
+
+    <repositories>
+        <repository>
+            <id>confluent</id>
+            <url>https://packages.confluent.io/maven/</url>
+        </repository>
+    </repositories>
 
     <dependencyManagement>
         <dependencies>
@@ -62,6 +70,12 @@
                 <groupId>org.mapstruct</groupId>
                 <artifactId>mapstruct</artifactId>
                 <version>${mapstruct.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.confluent</groupId>
+                <artifactId>kafka-avro-serializer</artifactId>
+                <version>${kafka-avro-serializer.version}</version>
             </dependency>
 
             <!--    GRPC dependencies management        -->

--- a/telemetry/collector/Dockerfile
+++ b/telemetry/collector/Dockerfile
@@ -1,0 +1,23 @@
+FROM maven:3.9-eclipse-temurin-21 AS builder
+
+WORKDIR /app
+
+COPY ../../pom.xml .
+COPY ../pom.xml ./telemetry/
+COPY ./pom.xml ./telemetry/collector/
+
+COPY ./src ./telemetry/collector/src
+COPY ../serialization/avro-schemas/src/main/avro ./telemetry/serialization/avro-schemas/src/main/avro
+
+RUN mvn -f ./pom.xml clean package -DskipTests
+
+
+FROM eclipse-temurin:21-jre-jammy
+
+WORKDIR /app
+
+COPY --from=builder /app/telemetry/collector/target/*.jar app.jar
+
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/telemetry/collector/Dockerfile
+++ b/telemetry/collector/Dockerfile
@@ -2,14 +2,9 @@ FROM maven:3.9-eclipse-temurin-21 AS builder
 
 WORKDIR /app
 
-COPY ../../pom.xml .
-COPY ../pom.xml ./telemetry/
-COPY ./pom.xml ./telemetry/collector/
+COPY . .
 
-COPY ./src ./telemetry/collector/src
-COPY ../serialization/avro-schemas/src/main/avro ./telemetry/serialization/avro-schemas/src/main/avro
-
-RUN mvn -f ./pom.xml clean package -DskipTests
+RUN mvn clean package -DskipTests
 
 
 FROM eclipse-temurin:21-jre-jammy

--- a/telemetry/collector/Dockerfile
+++ b/telemetry/collector/Dockerfile
@@ -1,16 +1,42 @@
+# --- Stage 1: Build the application in logical, cacheable steps ---
 FROM maven:3.9-eclipse-temurin-21 AS builder
 
 WORKDIR /app
 
-COPY . .
+# --- 1. Install all parent POMs ---
+# This creates a base layer with the project's "skeleton".
+# This layer will only be rebuilt if a POM file changes.
+COPY pom.xml .
+COPY telemetry/pom.xml ./telemetry/
+COPY telemetry/serialization/pom.xml ./telemetry/serialization/
 
-RUN mvn clean package -DskipTests
+# The -N flag tells Maven "install this POM, but do not build its modules".
+# This is fast and populates the local repo with the parent definitions.
+RUN mvn install -N
+
+# Install the telemetry and serialization parents specifically.
+RUN mvn install -N -f telemetry/pom.xml
+RUN mvn install -N -f telemetry/serialization/pom.xml
 
 
+# --- 2. Build and install the `avro-schemas` dependency ---
+# This layer depends on the parent POMs being installed.
+COPY telemetry/serialization/avro-schemas ./telemetry/serialization/avro-schemas
+RUN mvn install -f telemetry/serialization/avro-schemas/pom.xml -DskipTests
+
+
+# --- 3. Finally, build the `collector` application ---
+# This layer depends on all the above. It changes most frequently.
+COPY telemetry/collector ./telemetry/collector
+RUN mvn package -f telemetry/collector/pom.xml -DskipTests
+
+
+# --- Stage 2: Create the final, lightweight image ---
 FROM eclipse-temurin:21-jre-jammy
 
 WORKDIR /app
 
+# Copy ONLY the final JAR file from the 'builder' stage
 COPY --from=builder /app/telemetry/collector/target/*.jar app.jar
 
 EXPOSE 8080

--- a/telemetry/collector/Dockerfile
+++ b/telemetry/collector/Dockerfile
@@ -1,42 +1,30 @@
-# --- Stage 1: Build the application in logical, cacheable steps ---
+# Stage 1: Build application
 FROM maven:3.9-eclipse-temurin-21 AS builder
 
 WORKDIR /app
 
-# --- 1. Install all parent POMs ---
-# This creates a base layer with the project's "skeleton".
-# This layer will only be rebuilt if a POM file changes.
+# Install 'avro-schemas' dependency
 COPY pom.xml .
 COPY telemetry/pom.xml ./telemetry/
 COPY telemetry/serialization/pom.xml ./telemetry/serialization/
 
-# The -N flag tells Maven "install this POM, but do not build its modules".
-# This is fast and populates the local repo with the parent definitions.
 RUN mvn install -N
 
-# Install the telemetry and serialization parents specifically.
 RUN mvn install -N -f telemetry/pom.xml
 RUN mvn install -N -f telemetry/serialization/pom.xml
 
-
-# --- 2. Build and install the `avro-schemas` dependency ---
-# This layer depends on the parent POMs being installed.
+# Package the 'collector' module
 COPY telemetry/serialization/avro-schemas ./telemetry/serialization/avro-schemas
 RUN mvn install -f telemetry/serialization/avro-schemas/pom.xml -DskipTests
 
-
-# --- 3. Finally, build the `collector` application ---
-# This layer depends on all the above. It changes most frequently.
 COPY telemetry/collector ./telemetry/collector
 RUN mvn package -f telemetry/collector/pom.xml -DskipTests
 
-
-# --- Stage 2: Create the final, lightweight image ---
+# Stage 2: Create image
 FROM eclipse-temurin:21-jre-jammy
 
 WORKDIR /app
 
-# Copy ONLY the final JAR file from the 'builder' stage
 COPY --from=builder /app/telemetry/collector/target/*.jar app.jar
 
 EXPOSE 8080

--- a/telemetry/collector/pom.xml
+++ b/telemetry/collector/pom.xml
@@ -15,8 +15,73 @@
         <dependency>
             <groupId>ru.yandex.practicum</groupId>
             <artifactId>avro-schemas</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- Testing -->
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka-test</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.mapstruct</groupId>
+                            <artifactId>mapstruct-processor</artifactId>
+                            <version>${mapstruct.version}</version>
+                        </path>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${lombok.version}</version>
+                        </path>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok-mapstruct-binding</artifactId>
+                            <version>0.2.0</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/telemetry/collector/pom.xml
+++ b/telemetry/collector/pom.xml
@@ -34,10 +34,6 @@
             <artifactId>lombok</artifactId>
             <optional>true</optional>
         </dependency>
-        <dependency>
-            <groupId>io.confluent</groupId>
-            <artifactId>kafka-avro-serializer</artifactId>
-        </dependency>
 
         <!-- Testing -->
         <dependency>

--- a/telemetry/collector/pom.xml
+++ b/telemetry/collector/pom.xml
@@ -34,6 +34,10 @@
             <artifactId>lombok</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-avro-serializer</artifactId>
+        </dependency>
 
         <!-- Testing -->
         <dependency>

--- a/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/CollectorApplication.java
+++ b/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/CollectorApplication.java
@@ -1,0 +1,14 @@
+package ru.yandex.practicum.smarthometech.collector;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class CollectorApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(CollectorApplication.class, args);
+    }
+
+}
+

--- a/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/controller/EventController.java
+++ b/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/controller/EventController.java
@@ -25,7 +25,7 @@ public class EventController {
         eventProcessingService.processAndSendSensorEvent(event);
     }
 
-    @PostMapping("/events/hubs")
+    @PostMapping("/hubs")
     public void collectHubEvent(@Valid @RequestBody HubEvent event) {
         log.info("Received hub event: {}", event);
         eventProcessingService.processAndSendHubEvent(event);

--- a/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/controller/EventController.java
+++ b/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/controller/EventController.java
@@ -13,7 +13,7 @@ import ru.yandex.practicum.smarthometech.collector.service.EventProcessingServic
 
 @Slf4j
 @RestController
-@RequestMapping("/api/v1/events")
+@RequestMapping("/events")
 @RequiredArgsConstructor
 public class EventController {
 

--- a/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/controller/EventController.java
+++ b/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/controller/EventController.java
@@ -1,0 +1,34 @@
+package ru.yandex.practicum.smarthometech.collector.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import ru.yandex.practicum.smarthometech.collector.dto.HubEvent;
+import ru.yandex.practicum.smarthometech.collector.dto.SensorEvent;
+import ru.yandex.practicum.smarthometech.collector.service.EventProcessingService;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/events")
+@RequiredArgsConstructor
+public class EventController {
+
+    private final EventProcessingService eventProcessingService;
+
+    @PostMapping("/sensors")
+    public void handleSensorEvent(@Valid @RequestBody SensorEvent event) {
+        log.info("Received sensor event: {}", event);
+        eventProcessingService.processAndSendSensorEvent(event);
+    }
+
+    @PostMapping("/events/hubs")
+    public void collectHubEvent(@Valid @RequestBody HubEvent event) {
+        log.info("Received hub event: {}", event);
+        eventProcessingService.processAndSendHubEvent(event);
+    }
+
+}

--- a/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/dto/ActionType.java
+++ b/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/dto/ActionType.java
@@ -1,0 +1,8 @@
+package ru.yandex.practicum.smarthometech.collector.dto;
+
+public enum ActionType {
+    ACTIVATE,
+    DEACTIVATE,
+    INVERSE,
+    SET_VALUE
+}

--- a/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/dto/ClimateSensorEvent.java
+++ b/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/dto/ClimateSensorEvent.java
@@ -1,0 +1,22 @@
+package ru.yandex.practicum.smarthometech.collector.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class ClimateSensorEvent extends SensorEvent {
+
+    @Min(value = -40, message = "Temperature cannot be below -40 C")
+    @Max(value = 50, message = "Temperature cannot be above 50 C")
+    private int temperatureC;
+
+    @Min(value = 0, message = "Humidity cannot be negative")
+    @Max(value = 100, message = "Humidity cannot be over 100%")
+    private int humidity;
+
+    @Min(value = 0, message = "CO2 level cannot be negative")
+    private int co2Level;
+}

--- a/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/dto/ConditionOperation.java
+++ b/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/dto/ConditionOperation.java
@@ -1,0 +1,7 @@
+package ru.yandex.practicum.smarthometech.collector.dto;
+
+public enum ConditionOperation {
+    EQUALS,
+    GREATER_THAN,
+    LOWER_THAN
+}

--- a/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/dto/ConditionType.java
+++ b/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/dto/ConditionType.java
@@ -1,0 +1,10 @@
+package ru.yandex.practicum.smarthometech.collector.dto;
+
+public enum ConditionType {
+    MOTION,
+    LUMINOSITY,
+    SWITCH,
+    TEMPERATURE,
+    CO2LEVEL,
+    HUMIDITY
+}

--- a/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/dto/DeviceAction.java
+++ b/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/dto/DeviceAction.java
@@ -1,0 +1,19 @@
+package ru.yandex.practicum.smarthometech.collector.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode
+public class DeviceAction {
+
+    @NotBlank(message = "Sensor ID cannot be blank")
+    private String sensorId;
+
+    @NotNull(message = "Must have an action type")
+    private ActionType type;
+
+    private Integer value;
+}

--- a/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/dto/DeviceAddedEvent.java
+++ b/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/dto/DeviceAddedEvent.java
@@ -13,5 +13,5 @@ public class DeviceAddedEvent extends HubEvent {
     private String id;
 
     @NotBlank(message = "Type cannot be blank")
-    private String type;
+    private String deviceType;
 }

--- a/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/dto/DeviceAddedEvent.java
+++ b/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/dto/DeviceAddedEvent.java
@@ -1,0 +1,17 @@
+package ru.yandex.practicum.smarthometech.collector.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class DeviceAddedEvent extends HubEvent {
+
+    @NotNull(message = "Must have an ID")
+    private String id;
+
+    @NotBlank(message = "Type cannot be blank")
+    private String type;
+}

--- a/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/dto/DeviceRemovedEvent.java
+++ b/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/dto/DeviceRemovedEvent.java
@@ -1,0 +1,13 @@
+package ru.yandex.practicum.smarthometech.collector.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class DeviceRemovedEvent extends HubEvent {
+
+    @NotBlank(message = "ID cannot be blank")
+    private String id;
+}

--- a/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/dto/HubEvent.java
+++ b/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/dto/HubEvent.java
@@ -1,0 +1,31 @@
+package ru.yandex.practicum.smarthometech.collector.dto;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.Instant;
+import lombok.Data;
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = JsonTypeInfo.As.EXISTING_PROPERTY,
+    property = "type",
+    visible = true
+)
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = DeviceAddedEvent.class, name = "DEVICE_ADDED_EVENT"),
+    @JsonSubTypes.Type(value = DeviceRemovedEvent.class, name = "DEVICE_REMOVED_EVENT"),
+    @JsonSubTypes.Type(value = ScenarioAddedEvent.class, name = "SCENARIO_ADDED_EVENT"),
+    @JsonSubTypes.Type(value = ScenarioRemovedEvent.class, name = "SCENARIO_REMOVED_EVENT")
+})
+@Data
+public abstract class HubEvent {
+    @NotBlank
+    private String hubId;
+
+    private Instant timestamp = Instant.now();
+
+    @NotNull
+    private HubEventType type;
+}

--- a/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/dto/HubEvent.java
+++ b/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/dto/HubEvent.java
@@ -14,10 +14,10 @@ import lombok.Data;
     visible = true
 )
 @JsonSubTypes({
-    @JsonSubTypes.Type(value = DeviceAddedEvent.class, name = "DEVICE_ADDED_EVENT"),
-    @JsonSubTypes.Type(value = DeviceRemovedEvent.class, name = "DEVICE_REMOVED_EVENT"),
-    @JsonSubTypes.Type(value = ScenarioAddedEvent.class, name = "SCENARIO_ADDED_EVENT"),
-    @JsonSubTypes.Type(value = ScenarioRemovedEvent.class, name = "SCENARIO_REMOVED_EVENT")
+    @JsonSubTypes.Type(value = DeviceAddedEvent.class, name = "DEVICE_ADDED"),
+    @JsonSubTypes.Type(value = DeviceRemovedEvent.class, name = "DEVICE_REMOVED"),
+    @JsonSubTypes.Type(value = ScenarioAddedEvent.class, name = "SCENARIO_ADDED"),
+    @JsonSubTypes.Type(value = ScenarioRemovedEvent.class, name = "SCENARIO_REMOVED")
 })
 @Data
 public abstract class HubEvent {

--- a/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/dto/HubEventType.java
+++ b/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/dto/HubEventType.java
@@ -1,0 +1,8 @@
+package ru.yandex.practicum.smarthometech.collector.dto;
+
+public enum HubEventType {
+    DEVICE_ADDED_EVENT,
+    DEVICE_REMOVED_EVENT,
+    SCENARIO_ADDED_EVENT,
+    SCENARIO_REMOVED_EVENT
+}

--- a/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/dto/HubEventType.java
+++ b/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/dto/HubEventType.java
@@ -3,5 +3,6 @@ package ru.yandex.practicum.smarthometech.collector.dto;
 public enum HubEventType {
     DEVICE_ADDED,
     DEVICE_REMOVED,
-    SCENARIO_ADDED, SCENARIO_REMOVED_EVENT
+    SCENARIO_ADDED,
+    SCENARIO_REMOVED
 }

--- a/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/dto/HubEventType.java
+++ b/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/dto/HubEventType.java
@@ -1,8 +1,7 @@
 package ru.yandex.practicum.smarthometech.collector.dto;
 
 public enum HubEventType {
-    DEVICE_ADDED_EVENT,
-    DEVICE_REMOVED_EVENT,
-    SCENARIO_ADDED_EVENT,
-    SCENARIO_REMOVED_EVENT
+    DEVICE_ADDED,
+    DEVICE_REMOVED,
+    SCENARIO_ADDED, SCENARIO_REMOVED_EVENT
 }

--- a/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/dto/LightSensorEvent.java
+++ b/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/dto/LightSensorEvent.java
@@ -1,0 +1,16 @@
+package ru.yandex.practicum.smarthometech.collector.dto;
+
+import jakarta.validation.constraints.Min;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class LightSensorEvent extends SensorEvent {
+
+    @Min(value = 0, message = "Link quality cannot be negative")
+    private int linkQuality;
+
+    @Min(value = 0, message = "Luminosity cannot be negative")
+    private int luminosity;
+}

--- a/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/dto/MotionSensorEvent.java
+++ b/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/dto/MotionSensorEvent.java
@@ -1,0 +1,18 @@
+package ru.yandex.practicum.smarthometech.collector.dto;
+
+import jakarta.validation.constraints.Min;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class MotionSensorEvent extends SensorEvent {
+
+    @Min(value = 0, message = "Link quality cannot be negative")
+    private int linkQuality;
+
+    private boolean motion;
+
+    @Min(value = 0, message = "Voltage cannot be negative")
+    private int voltage;
+}

--- a/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/dto/ScenarioAddedEvent.java
+++ b/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/dto/ScenarioAddedEvent.java
@@ -1,0 +1,23 @@
+package ru.yandex.practicum.smarthometech.collector.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import java.util.List;
+import org.springframework.validation.annotation.Validated;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@Validated
+public class ScenarioAddedEvent extends HubEvent {
+
+    @NotBlank(message = "Scenario name cannot be blank")
+    @Size(min = 3, message = "Scenario name must be at least 3 characters long")
+    private String name;
+
+    private List<ScenarioCondition> conditions;
+
+    private List<DeviceAction> actions;
+}

--- a/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/dto/ScenarioCondition.java
+++ b/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/dto/ScenarioCondition.java
@@ -1,0 +1,22 @@
+package ru.yandex.practicum.smarthometech.collector.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode
+public class ScenarioCondition {
+
+    @NotBlank(message = "Sensor ID cannot be blank")
+    private String sensorId;
+
+    @NotNull(message = "Must have a condition type")
+    private ConditionType type;
+
+    @NotNull(message = "Must have a condition operation")
+    private ConditionOperation operation;
+
+    private Integer value;
+}

--- a/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/dto/ScenarioRemovedEvent.java
+++ b/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/dto/ScenarioRemovedEvent.java
@@ -1,0 +1,15 @@
+package ru.yandex.practicum.smarthometech.collector.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class ScenarioRemovedEvent extends HubEvent {
+
+    @NotBlank(message = "Scenario name cannot be blank")
+    @Size(min = 3, message = "Scenario name must be at least 3 characters long")
+    private String name;
+}

--- a/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/dto/SensorEvent.java
+++ b/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/dto/SensorEvent.java
@@ -15,11 +15,11 @@ import java.time.Instant;
     visible = true
 )
 @JsonSubTypes({
-    @JsonSubTypes.Type(value = LightSensorEvent.class, name = "LIGHT_SENSOR_EVENT"),
-    @JsonSubTypes.Type(value = MotionSensorEvent.class, name = "MOTION_SENSOR_EVENT"),
-    @JsonSubTypes.Type(value = TemperatureSensorEvent.class, name = "TEMPERATURE_SENSOR_EVENT"),
-    @JsonSubTypes.Type(value = ClimateSensorEvent.class, name = "CLIMATE_SENSOR_EVENT"),
-    @JsonSubTypes.Type(value = SwitchSensorEvent.class, name = "SWITCH_SENSOR_EVENT")
+    @JsonSubTypes.Type(value = LightSensorEvent.class, name = "LIGHT_SENSOR"),
+    @JsonSubTypes.Type(value = MotionSensorEvent.class, name = "MOTION_SENSOR"),
+    @JsonSubTypes.Type(value = TemperatureSensorEvent.class, name = "TEMPERATURE_SENSOR"),
+    @JsonSubTypes.Type(value = ClimateSensorEvent.class, name = "CLIMATE_SENSOR"),
+    @JsonSubTypes.Type(value = SwitchSensorEvent.class, name = "SWITCH_SENSOR")
 })
 @Data
 public abstract class SensorEvent {

--- a/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/dto/SensorEvent.java
+++ b/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/dto/SensorEvent.java
@@ -1,0 +1,36 @@
+package ru.yandex.practicum.smarthometech.collector.dto;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+import java.time.Instant;
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = JsonTypeInfo.As.EXISTING_PROPERTY,
+    property = "type",
+    visible = true
+)
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = LightSensorEvent.class, name = "LIGHT_SENSOR_EVENT"),
+    @JsonSubTypes.Type(value = MotionSensorEvent.class, name = "MOTION_SENSOR_EVENT"),
+    @JsonSubTypes.Type(value = TemperatureSensorEvent.class, name = "TEMPERATURE_SENSOR_EVENT"),
+    @JsonSubTypes.Type(value = ClimateSensorEvent.class, name = "CLIMATE_SENSOR_EVENT"),
+    @JsonSubTypes.Type(value = SwitchSensorEvent.class, name = "SWITCH_SENSOR_EVENT")
+})
+@Data
+public abstract class SensorEvent {
+    @NotBlank
+    private String id;
+
+    @NotBlank
+    private String hubId;
+
+    private Instant timestamp = Instant.now();
+
+    @NotNull
+    private SensorEventType type;
+}

--- a/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/dto/SensorEvent.java
+++ b/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/dto/SensorEvent.java
@@ -15,11 +15,11 @@ import java.time.Instant;
     visible = true
 )
 @JsonSubTypes({
-    @JsonSubTypes.Type(value = LightSensorEvent.class, name = "LIGHT_SENSOR"),
-    @JsonSubTypes.Type(value = MotionSensorEvent.class, name = "MOTION_SENSOR"),
-    @JsonSubTypes.Type(value = TemperatureSensorEvent.class, name = "TEMPERATURE_SENSOR"),
-    @JsonSubTypes.Type(value = ClimateSensorEvent.class, name = "CLIMATE_SENSOR"),
-    @JsonSubTypes.Type(value = SwitchSensorEvent.class, name = "SWITCH_SENSOR")
+    @JsonSubTypes.Type(value = LightSensorEvent.class, name = "LIGHT_SENSOR_EVENT"),
+    @JsonSubTypes.Type(value = MotionSensorEvent.class, name = "MOTION_SENSOR_EVENT"),
+    @JsonSubTypes.Type(value = TemperatureSensorEvent.class, name = "TEMPERATURE_SENSOR_EVENT"),
+    @JsonSubTypes.Type(value = ClimateSensorEvent.class, name = "CLIMATE_SENSOR_EVENT"),
+    @JsonSubTypes.Type(value = SwitchSensorEvent.class, name = "SWITCH_SENSOR_EVENT")
 })
 @Data
 public abstract class SensorEvent {

--- a/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/dto/SensorEventType.java
+++ b/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/dto/SensorEventType.java
@@ -1,9 +1,9 @@
 package ru.yandex.practicum.smarthometech.collector.dto;
 
 public enum SensorEventType {
-    MOTION_SENSOR_EVENT,
-    TEMPERATURE_SENSOR_EVENT,
-    LIGHT_SENSOR_EVENT,
-    CLIMATE_SENSOR_EVENT,
-    SWITCH_SENSOR_EVENT
+    MOTION_SENSOR,
+    TEMPERATURE_SENSOR,
+    LIGHT_SENSOR,
+    CLIMATE_SENSOR,
+    SWITCH_SENSOR
 }

--- a/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/dto/SensorEventType.java
+++ b/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/dto/SensorEventType.java
@@ -1,7 +1,7 @@
 package ru.yandex.practicum.smarthometech.collector.dto;
 
 public enum SensorEventType {
-    MOTION_SENSOR,
+    MOTION_SENSOR_EVENT,
     TEMPERATURE_SENSOR_EVENT,
     LIGHT_SENSOR_EVENT,
     CLIMATE_SENSOR_EVENT,

--- a/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/dto/SensorEventType.java
+++ b/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/dto/SensorEventType.java
@@ -1,0 +1,9 @@
+package ru.yandex.practicum.smarthometech.collector.dto;
+
+public enum SensorEventType {
+    MOTION_SENSOR_EVENT,
+    TEMPERATURE_SENSOR_EVENT,
+    LIGHT_SENSOR_EVENT,
+    CLIMATE_SENSOR_EVENT,
+    SWITCH_SENSOR_EVENT
+}

--- a/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/dto/SensorEventType.java
+++ b/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/dto/SensorEventType.java
@@ -2,8 +2,8 @@ package ru.yandex.practicum.smarthometech.collector.dto;
 
 public enum SensorEventType {
     MOTION_SENSOR,
-    TEMPERATURE_SENSOR,
-    LIGHT_SENSOR,
-    CLIMATE_SENSOR,
-    SWITCH_SENSOR
+    TEMPERATURE_SENSOR_EVENT,
+    LIGHT_SENSOR_EVENT,
+    CLIMATE_SENSOR_EVENT,
+    SWITCH_SENSOR_EVENT
 }

--- a/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/dto/SwitchSensorEvent.java
+++ b/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/dto/SwitchSensorEvent.java
@@ -1,0 +1,10 @@
+package ru.yandex.practicum.smarthometech.collector.dto;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class SwitchSensorEvent extends SensorEvent {
+    private boolean state;
+}

--- a/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/dto/TemperatureSensorEvent.java
+++ b/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/dto/TemperatureSensorEvent.java
@@ -1,0 +1,19 @@
+package ru.yandex.practicum.smarthometech.collector.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class TemperatureSensorEvent extends SensorEvent {
+
+    @Min(value = -40, message = "Temperature cannot be below -40 C")
+    @Max(value = 50, message = "Temperature cannot be above 50 C")
+    private int temperature_c;
+
+    @Min(value = -40, message = "Temperature cannot be below -40 F")
+    @Max(value = 120, message = "Temperature cannot be above 120 F")
+    private int temperature_f;
+}

--- a/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/dto/TemperatureSensorEvent.java
+++ b/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/dto/TemperatureSensorEvent.java
@@ -11,9 +11,9 @@ public class TemperatureSensorEvent extends SensorEvent {
 
     @Min(value = -40, message = "Temperature cannot be below -40 C")
     @Max(value = 50, message = "Temperature cannot be above 50 C")
-    private int temperature_c;
+    private int temperatureC;
 
     @Min(value = -40, message = "Temperature cannot be below -40 F")
     @Max(value = 120, message = "Temperature cannot be above 120 F")
-    private int temperature_f;
+    private int temperatureF;
 }

--- a/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/kafka/CustomAvroSerializer.java
+++ b/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/kafka/CustomAvroSerializer.java
@@ -1,0 +1,38 @@
+package ru.yandex.practicum.smarthometech.collector.kafka;
+
+import org.apache.avro.generic.GenericContainer;
+import org.apache.avro.io.BinaryEncoder;
+import org.apache.avro.io.DatumWriter;
+import org.apache.avro.io.EncoderFactory;
+import org.apache.avro.specific.SpecificDatumWriter;
+import org.apache.kafka.common.errors.SerializationException;
+import org.apache.kafka.common.serialization.Serializer;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+public class CustomAvroSerializer<T extends GenericContainer> implements Serializer<T> {
+
+    @Override
+    public byte[] serialize(String topic, T data) {
+        if (data == null) {
+            return null;
+        }
+
+        try {
+            DatumWriter<T> datumWriter = new SpecificDatumWriter<>(data.getSchema());
+            ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+            BinaryEncoder encoder = EncoderFactory.get().binaryEncoder(outputStream, null);
+
+            datumWriter.write(data, encoder);
+            encoder.flush();
+
+            byte[] result = outputStream.toByteArray();
+            outputStream.close();
+            return result;
+
+        } catch (IOException e) {
+            throw new SerializationException("Error serializing Avro message for topic " + topic, e);
+        }
+    }
+}

--- a/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/kafka/TelemetryKafkaProducer.java
+++ b/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/kafka/TelemetryKafkaProducer.java
@@ -1,4 +1,4 @@
-package ru.yandex.practicum.smarthometech.collector.service;
+package ru.yandex.practicum.smarthometech.collector.kafka;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/kafka/TelemetryKafkaProducer.java
+++ b/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/kafka/TelemetryKafkaProducer.java
@@ -24,7 +24,9 @@ public class TelemetryKafkaProducer {
     public void sendSensorEvent(SensorEventAvro event) {
         log.info("Sending sensor event to Kafka topic '{}': {}", sensorTopic, event);
 
-        kafkaTemplate.send(sensorTopic, event.getHubId(), event).whenComplete((result, ex) -> {
+        long eventTimestamp = event.getTimestamp().toEpochMilli();
+
+        kafkaTemplate.send(sensorTopic,  null, eventTimestamp, event.getHubId(), event).whenComplete((result, ex) -> {
             if (ex == null) {
                 log.info("Successfully sent sensor event for hubId {} to offset {}",
                     event.getHubId(), result.getRecordMetadata().offset());
@@ -37,7 +39,9 @@ public class TelemetryKafkaProducer {
     public void sendHubEvent(HubEventAvro event) {
         log.info("Sending hub event to Kafka topic '{}': {}", hubTopic, event);
 
-        kafkaTemplate.send(hubTopic, event.getHubId(), event).whenComplete((result, ex) -> {
+        long eventTimestamp = event.getTimestamp().toEpochMilli();
+
+        kafkaTemplate.send(hubTopic, null, eventTimestamp, event.getHubId(), event).whenComplete((result, ex) -> {
             if (ex == null) {
                 log.info("Successfully sent hub event for hubId {} to offset {}",
                     event.getHubId(), result.getRecordMetadata().offset());

--- a/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/mapper/EventMapper.java
+++ b/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/mapper/EventMapper.java
@@ -1,0 +1,88 @@
+package ru.yandex.practicum.smarthometech.collector.mapper;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import ru.yandex.practicum.kafka.telemetry.event.ClimateSensorAvro;
+import ru.yandex.practicum.kafka.telemetry.event.DeviceAddedEventAvro;
+import ru.yandex.practicum.kafka.telemetry.event.HubEventAvro;
+import ru.yandex.practicum.kafka.telemetry.event.LightSensorAvro;
+import ru.yandex.practicum.kafka.telemetry.event.MotionSensorAvro;
+import ru.yandex.practicum.kafka.telemetry.event.ScenarioAddedEventAvro;
+import ru.yandex.practicum.kafka.telemetry.event.ScenarioRemovedEventAvro;
+import ru.yandex.practicum.kafka.telemetry.event.SensorEventAvro;
+import ru.yandex.practicum.kafka.telemetry.event.SwitchSensorAvro;
+import ru.yandex.practicum.kafka.telemetry.event.TemperatureSensorAvro;
+import ru.yandex.practicum.smarthometech.collector.dto.ClimateSensorEvent;
+import ru.yandex.practicum.smarthometech.collector.dto.DeviceAddedEvent;
+import ru.yandex.practicum.smarthometech.collector.dto.DeviceRemovedEvent;
+import ru.yandex.practicum.smarthometech.collector.dto.LightSensorEvent;
+import ru.yandex.practicum.smarthometech.collector.dto.MotionSensorEvent;
+import ru.yandex.practicum.smarthometech.collector.dto.ScenarioAddedEvent;
+import ru.yandex.practicum.smarthometech.collector.dto.ScenarioRemovedEvent;
+import ru.yandex.practicum.smarthometech.collector.dto.SwitchSensorEvent;
+import ru.yandex.practicum.smarthometech.collector.dto.TemperatureSensorEvent;
+import ru.yandex.practicum.smarthometech.collector.mapper.qualifier.FullEvent;
+import ru.yandex.practicum.smarthometech.collector.mapper.qualifier.Payload;
+
+@Mapper(componentModel = "spring")
+public interface EventMapper {
+
+    // --- SENSOR EVENT MAPPERS ---
+
+    @Mapping(target = "payload", source = "dto", qualifiedBy = Payload.class)
+    @FullEvent
+    SensorEventAvro toAvro(LightSensorEvent dto);
+    @Payload
+    LightSensorAvro toPayload(LightSensorEvent dto);
+
+    @Mapping(target = "payload", source = "dto", qualifiedBy = Payload.class)
+    @FullEvent
+    SensorEventAvro toAvro(MotionSensorEvent dto);
+    @Payload
+    MotionSensorAvro toPayload(MotionSensorEvent dto);
+
+    @Mapping(target = "payload", source = "dto", qualifiedBy = Payload.class)
+    @FullEvent
+    SensorEventAvro toAvro(ClimateSensorEvent dto);
+    @Payload
+    ClimateSensorAvro toPayload(ClimateSensorEvent dto);
+
+    @Mapping(target = "payload", source = "dto", qualifiedBy = Payload.class)
+    @FullEvent
+    SensorEventAvro toAvro(SwitchSensorEvent dto);
+    @Payload
+    SwitchSensorAvro toPayload(SwitchSensorEvent dto);
+
+    @Mapping(target = "payload", source = "dto", qualifiedBy = Payload.class)
+    @FullEvent
+    SensorEventAvro toAvro(TemperatureSensorEvent dto);
+    @Payload
+    TemperatureSensorAvro toPayload(TemperatureSensorEvent dto);
+
+    // --- HUB EVENT MAPPERS ---
+
+    @Mapping(target = "payload", source = "dto", qualifiedBy = Payload.class)
+    @FullEvent
+    HubEventAvro toAvro(DeviceAddedEvent dto);
+    @Payload
+    DeviceAddedEventAvro toPayload(DeviceAddedEvent dto);
+
+    @Mapping(target = "payload", source = "dto", qualifiedBy = Payload.class)
+    @FullEvent
+    HubEventAvro toAvro(DeviceRemovedEvent dto);
+    @Payload
+    DeviceRemovedEvent toPayload(DeviceRemovedEvent dto);
+
+    @Mapping(target = "payload", source = "dto", qualifiedBy = Payload.class)
+    @FullEvent
+    HubEventAvro toAvro(ScenarioAddedEvent dto);
+    @Payload
+    ScenarioAddedEventAvro toPayload(ScenarioAddedEvent dto);
+
+    @Mapping(target = "payload", source = "dto", qualifiedBy = Payload.class)
+    @FullEvent
+    HubEventAvro toAvro(ScenarioRemovedEvent dto);
+    @Payload
+    ScenarioRemovedEventAvro toPayload(ScenarioRemovedEvent dto);
+
+}

--- a/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/mapper/EventMapper.java
+++ b/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/mapper/EventMapper.java
@@ -65,6 +65,7 @@ public interface EventMapper {
     @FullEvent
     HubEventAvro toAvro(DeviceAddedEvent dto);
     @Payload
+    @Mapping(target = "type", source = "deviceType")
     DeviceAddedEventAvro toPayload(DeviceAddedEvent dto);
 
     @Mapping(target = "payload", source = "dto", qualifiedBy = Payload.class)

--- a/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/mapper/qualifier/FullEvent.java
+++ b/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/mapper/qualifier/FullEvent.java
@@ -1,0 +1,13 @@
+package ru.yandex.practicum.smarthometech.collector.mapper.qualifier;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.mapstruct.Qualifier;
+
+@Qualifier
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.CLASS)
+public @interface FullEvent {
+}

--- a/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/mapper/qualifier/Payload.java
+++ b/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/mapper/qualifier/Payload.java
@@ -1,0 +1,13 @@
+package ru.yandex.practicum.smarthometech.collector.mapper.qualifier;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.mapstruct.Qualifier;
+
+@Qualifier
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.CLASS)
+public @interface Payload {
+}

--- a/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/service/EventProcessingService.java
+++ b/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/service/EventProcessingService.java
@@ -1,0 +1,11 @@
+package ru.yandex.practicum.smarthometech.collector.service;
+
+import ru.yandex.practicum.smarthometech.collector.dto.HubEvent;
+import ru.yandex.practicum.smarthometech.collector.dto.SensorEvent;
+
+public interface EventProcessingService {
+
+    void processAndSendSensorEvent(SensorEvent event);
+
+    void processAndSendHubEvent(HubEvent event);
+}

--- a/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/service/EventProcessingServiceImpl.java
+++ b/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/service/EventProcessingServiceImpl.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service;
 import ru.yandex.practicum.kafka.telemetry.event.HubEventAvro;
 import ru.yandex.practicum.kafka.telemetry.event.SensorEventAvro;
 import ru.yandex.practicum.smarthometech.collector.dto.*;
+import ru.yandex.practicum.smarthometech.collector.kafka.TelemetryKafkaProducer;
 import ru.yandex.practicum.smarthometech.collector.mapper.EventMapper;
 
 @Service

--- a/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/service/EventProcessingServiceImpl.java
+++ b/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/service/EventProcessingServiceImpl.java
@@ -1,0 +1,41 @@
+package ru.yandex.practicum.smarthometech.collector.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import ru.yandex.practicum.kafka.telemetry.event.HubEventAvro;
+import ru.yandex.practicum.kafka.telemetry.event.SensorEventAvro;
+import ru.yandex.practicum.smarthometech.collector.dto.*;
+import ru.yandex.practicum.smarthometech.collector.mapper.EventMapper;
+
+@Service
+@RequiredArgsConstructor
+public class EventProcessingServiceImpl implements EventProcessingService {
+
+    private final EventMapper eventMapper;
+    private final TelemetryKafkaProducer kafkaProducer;
+
+    @Override
+    public void processAndSendSensorEvent(SensorEvent event) {
+        SensorEventAvro avroEvent = switch (event) {
+            case LightSensorEvent e -> eventMapper.toAvro(e);
+            case MotionSensorEvent e -> eventMapper.toAvro(e);
+            case ClimateSensorEvent e -> eventMapper.toAvro(e);
+            case SwitchSensorEvent e -> eventMapper.toAvro(e);
+            case TemperatureSensorEvent e -> eventMapper.toAvro(e);
+            default -> throw new IllegalArgumentException("Unsupported sensor event type: " + event.getType());
+        };
+        kafkaProducer.sendSensorEvent(avroEvent);
+    }
+
+    @Override
+    public void processAndSendHubEvent(HubEvent event) {
+        HubEventAvro avroEvent = switch (event) {
+            case DeviceAddedEvent e -> eventMapper.toAvro(e);
+            case DeviceRemovedEvent e -> eventMapper.toAvro(e);
+            case ScenarioAddedEvent e -> eventMapper.toAvro(e);
+            case ScenarioRemovedEvent e -> eventMapper.toAvro(e);
+            default -> throw new IllegalArgumentException("Unsupported hub event type: " + event.getType());
+        };
+        kafkaProducer.sendHubEvent(avroEvent);
+    }
+}

--- a/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/service/TelemetryKafkaProducer.java
+++ b/telemetry/collector/src/main/java/ru/yandex/practicum/smarthometech/collector/service/TelemetryKafkaProducer.java
@@ -1,0 +1,49 @@
+package ru.yandex.practicum.smarthometech.collector.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+import ru.yandex.practicum.kafka.telemetry.event.HubEventAvro;
+import ru.yandex.practicum.kafka.telemetry.event.SensorEventAvro;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TelemetryKafkaProducer {
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    @Value("${kafka.topic.sensors}")
+    private String sensorTopic;
+
+    @Value("${kafka.topic.hubs}")
+    private String hubTopic;
+
+    public void sendSensorEvent(SensorEventAvro event) {
+        log.info("Sending sensor event to Kafka topic '{}': {}", sensorTopic, event);
+
+        kafkaTemplate.send(sensorTopic, event.getHubId(), event).whenComplete((result, ex) -> {
+            if (ex == null) {
+                log.info("Successfully sent sensor event for hubId {} to offset {}",
+                    event.getHubId(), result.getRecordMetadata().offset());
+            } else {
+                log.error("Failed to send sensor event for hubId {}: {}", event.getHubId(), ex.getMessage());
+            }
+        });
+    }
+
+    public void sendHubEvent(HubEventAvro event) {
+        log.info("Sending hub event to Kafka topic '{}': {}", hubTopic, event);
+
+        kafkaTemplate.send(hubTopic, event.getHubId(), event).whenComplete((result, ex) -> {
+            if (ex == null) {
+                log.info("Successfully sent hub event for hubId {} to offset {}",
+                    event.getHubId(), result.getRecordMetadata().offset());
+            } else {
+                log.error("Failed to send hub event for hubId {}: {}", event.getHubId(), ex.getMessage());
+            }
+        });
+    }
+}

--- a/telemetry/collector/src/main/resources/application.yaml
+++ b/telemetry/collector/src/main/resources/application.yaml
@@ -3,9 +3,7 @@ spring:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
-      value-serializer: io.confluent.kafka.serializers.KafkaAvroSerializer
-    properties:
-      schema.registry.url: ${KAFKA_SCHEMA_REGISTRY_URL:http://localhost:8081}
+      value-serializer: ru.yandex.practicum.smarthometech.collector.kafka.CustomAvroSerializer
 
 kafka:
   topic:

--- a/telemetry/collector/src/main/resources/application.yaml
+++ b/telemetry/collector/src/main/resources/application.yaml
@@ -1,0 +1,13 @@
+spring:
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: io.confluent.kafka.serializers.KafkaAvroSerializer
+    properties:
+      schema.registry.url: ${KAFKA_SCHEMA_REGISTRY_URL:http://localhost:8081}
+
+kafka:
+  topic:
+    sensors: telemetry.sensors.v1
+    hubs: telemetry.hubs.v1

--- a/telemetry/collector/src/main/resources/application.yaml
+++ b/telemetry/collector/src/main/resources/application.yaml
@@ -3,7 +3,7 @@ spring:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
-      value-serializer: ru.yandex.practicum.smarthometech.collector.kafka.CustomAvroSerializer
+      value-serializer: ru.yandex.practicum.telemetry.serialization.CustomAvroSerializer
 
 kafka:
   topic:

--- a/telemetry/serialization/avro-schemas/src/main/avro/telemetry/HubEvent.avdl
+++ b/telemetry/serialization/avro-schemas/src/main/avro/telemetry/HubEvent.avdl
@@ -1,4 +1,77 @@
 @namespace("ru.yandex.practicum.kafka.telemetry.event")
 protocol HubEventProtocol {
 
+	enum DeviceTypeAvro {
+		MOTION_SENSOR,
+		TEMPERATURE_SENSOR,
+		LIGHT_SENSOR,
+		CLIMATE_SENSOR,
+		SWITCH_SENSOR
+	}
+
+	enum ConditionTypeAvro {
+		MOTION,
+		LUMINOSITY,
+		SWITCH,
+		TEMPERATURE,
+		CO2LEVEL,
+		HUMIDITY
+	}
+
+	enum ConditionOperationAvro {
+		EQUALS,
+		GREATER_THAN,
+		LOWER_THAN
+	}
+
+	enum ActionTypeAvro {
+		ACTIVATE,
+		DEACTIVATE,
+		INVERSE,
+		SET_VALUE
+	}
+
+	record DeviceAddedEventAvro {
+		string id;
+		DeviceTypeAvro type;
+	}
+
+	record DeviceRemovedEventAvro {
+		string id;
+	}
+
+	record ScenarioConditionAvro {
+		string sensor_id;
+		ConditionTypeAvro type;
+		ConditionOperationAvro operation;
+		union { null, int, boolean } value = null;
+	}
+
+	record DeviceActionAvro {
+		string sensor_id;
+		ActionTypeAvro type;
+		int? value = null;
+	}
+
+	record ScenarioAddedEventAvro {
+		string name;
+		array<ScenarioConditionAvro> conditions;
+		array<DeviceActionAvro> actions;
+	}
+
+	record ScenarioRemovedEventAvro {
+		string name;
+	}
+
+	record HubEventAvro {
+		string hub_id;
+		@logicalType("timestamp-millis") long timestamp;
+		union {
+			DeviceAddedEventAvro,
+			DeviceRemovedEventAvro,
+			ScenarioAddedEventAvro,
+			ScenarioRemovedEventAvro
+		} payload;
+	}
+
 }

--- a/telemetry/serialization/avro-schemas/src/main/avro/telemetry/SensorEvent.avdl
+++ b/telemetry/serialization/avro-schemas/src/main/avro/telemetry/SensorEvent.avdl
@@ -29,7 +29,7 @@ protocol SensorEventProtocol {
 
 	record SensorEventAvro {
 		string id;
-		string hubId;
+		string hub_id;
 		@logicalType("timestamp-millis") long timestamp;
 		union {
 			ClimateSensorAvro,

--- a/telemetry/serialization/avro-schemas/src/main/avro/telemetry/SensorEvent.avdl
+++ b/telemetry/serialization/avro-schemas/src/main/avro/telemetry/SensorEvent.avdl
@@ -1,4 +1,43 @@
 @namespace("ru.yandex.practicum.kafka.telemetry.event")
 protocol SensorEventProtocol {
 
+	record ClimateSensorAvro {
+		int temperature_c;
+		int humidity;
+		int co2_level;
+	}
+
+	record LightSensorAvro {
+		int link_quality;
+		int luminosity;
+	}
+
+	record MotionSensorAvro {
+		int link_quality;
+		boolean motion;
+		int voltage;
+	}
+
+	record SwitchSensorAvro {
+		boolean state;
+	}
+
+	record TemperatureSensorAvro {
+		int temperature_c;
+		int temperature_f;
+	}
+
+	record SensorEventAvro {
+		string id;
+		string hubId;
+		@logicalType("timestamp-millis") long timestamp;
+		union {
+			ClimateSensorAvro,
+			LightSensorAvro,
+			MotionSensorAvro,
+			SwitchSensorAvro,
+			TemperatureSensorAvro
+		} payload;
+	}
+
 }

--- a/telemetry/serialization/avro-schemas/src/main/java/ru/yandex/practicum/telemetry/serialization/CustomAvroSerializer.java
+++ b/telemetry/serialization/avro-schemas/src/main/java/ru/yandex/practicum/telemetry/serialization/CustomAvroSerializer.java
@@ -1,4 +1,4 @@
-package ru.yandex.practicum.smarthometech.collector.kafka;
+package ru.yandex.practicum.telemetry.serialization;
 
 import org.apache.avro.generic.GenericContainer;
 import org.apache.avro.io.BinaryEncoder;


### PR DESCRIPTION
Данный Pull Request добавляет реализацию сервиса `collector` согласно ТЗ спринта №19.

**Основные изменения:**
*   Реализованы два REST-эндпоинта (`/events/sensors` и `/events/hubs`) для приёма полиморфных JSON-событий от хабов.
*   Настроена отправка данных в топики **Kafka** с использованием `KafkaTemplate`.
*   Сериализация данных в Avro выполняется кастомным `Serializer`-ом. Использование `KafkaAvroSerializer` от Confluent было невозможно из-за отсутствия **Schema Registry** в CI-окружении.
*   Добавлены DTO с валидацией и мапперы на основе **MapStruct** для преобразования входящих данных в Avro-объекты.
*   Вся инфраструктура (**Kafka**, сервис) запускается через `compose.yaml`.