### PR TITLE
Централизация конфигурации и унификация зависимостей

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -76,6 +76,21 @@ services:
       timeout: 5s
       retries: 5
 
+  config-server:
+    build:
+      context: .
+      dockerfile: ./infra/config-server/Dockerfile
+    container_name: config-server
+    ports:
+      - "8888:8888"
+    restart: unless-stopped
+    healthcheck:
+      test: [ "CMD-SHELL", "curl -f http://localhost:8888/actuator/health || exit 1" ]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
+
   collector-service:
       build:
         context: .
@@ -84,12 +99,13 @@ services:
       depends_on:
         kafka:
           condition: service_healthy
+        config-server:
+          condition: service_healthy
       ports:
         - "9090:9090"
       restart: unless-stopped
       environment:
-        KAFKA_BOOTSTRAP_SERVERS: kafka:29092
-        KAFKA_SCHEMA_REGISTRY_URL: http://schema-registry:8081
+        SPRING_CONFIG_IMPORT: "configserver:http://config-server:8888"
 
   aggregator-service:
       build:
@@ -99,12 +115,13 @@ services:
       depends_on:
         kafka:
           condition: service_healthy
+        config-server:
+          condition: service_healthy
       ports:
         - "8080:8080"
       restart: unless-stopped
       environment:
-        KAFKA_BOOTSTRAP_SERVERS: kafka:29092
-        KAFKA_SCHEMA_REGISTRY_URL: http://schema-registry:8081
+        SPRING_CONFIG_IMPORT: "configserver:http://config-server:8888"
 
   analyzer-service:
       build:
@@ -116,12 +133,10 @@ services:
           condition: service_healthy
         postgres:
           condition: service_healthy
+        config-server:
+          condition: service_healthy
       ports:
         - "8082:8082"
       restart: unless-stopped
       environment:
-        DATASOURCE_URL: jdbc:postgresql://postgres:5432/smart_home_tech
-        DATASOURCE_USERNAME: postgres
-        DATASOURCE_PASSWORD: postgres
-        KAFKA_BOOTSTRAP_SERVERS: kafka:29092
-        KAFKA_SCHEMA_REGISTRY_URL: http://schema-registry:8081
+        SPRING_CONFIG_IMPORT: "configserver:http://config-server:8888"

--- a/compose.yaml
+++ b/compose.yaml
@@ -21,7 +21,7 @@ services:
       interval: 5s
       timeout: 2s
       retries: 5
-      start_period: 5s
+      start_period: 1s
 
   kafka-init-topics:
     image: confluentinc/confluent-local:7.5.0
@@ -75,6 +75,7 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+      start_period: 1s
 
   config-server:
     build:
@@ -89,7 +90,7 @@ services:
       interval: 10s
       timeout: 5s
       retries: 10
-      start_period: 10s
+      start_period: 1s
 
   collector-service:
       build:
@@ -106,6 +107,7 @@ services:
       restart: unless-stopped
       environment:
         SPRING_CONFIG_IMPORT: "configserver:http://config-server:8888"
+        SPRING_PROFILES_ACTIVE: docker
 
   aggregator-service:
       build:
@@ -122,6 +124,7 @@ services:
       restart: unless-stopped
       environment:
         SPRING_CONFIG_IMPORT: "configserver:http://config-server:8888"
+        SPRING_PROFILES_ACTIVE: docker
 
   analyzer-service:
       build:
@@ -140,3 +143,4 @@ services:
       restart: unless-stopped
       environment:
         SPRING_CONFIG_IMPORT: "configserver:http://config-server:8888"
+        SPRING_PROFILES_ACTIVE: docker

--- a/infra/config-server/Dockerfile
+++ b/infra/config-server/Dockerfile
@@ -10,11 +10,17 @@ COPY infra/config-server/pom.xml ./infra/config-server/
 
 RUN mvn install -N
 RUN mvn install -N -f infra/pom.xml
-RUN mvn install -N -f infra/config-server/pom.xml
+
+# Copy configs
+WORKDIR /app/infra/config-server/src/main/resources/config/telemetry
+COPY telemetry/collector/src/main/resources/application.yaml ./collector/
+COPY telemetry/aggregator/src/main/resources/application.yaml ./aggregator/
+COPY telemetry/analyzer/src/main/resources/application.yaml ./analyzer/
 
 # Build the server config application
+WORKDIR /app
 COPY infra/config-server ./infra/config-server
-RUN mvn -f /app/pom.xml package -DskipTests
+RUN mvn -f infra/config-server/pom.xml package -DskipTests
 
 # Stage 2: Create image
 FROM eclipse-temurin:21-jre-jammy
@@ -23,6 +29,6 @@ WORKDIR /app
 
 EXPOSE 8888
 
-COPY --from=builder /app/target/*.jar app.jar
+COPY --from=builder /app/infra/config-server/target/*.jar app.jar
 
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/infra/config-server/Dockerfile
+++ b/infra/config-server/Dockerfile
@@ -1,0 +1,28 @@
+# Stage 1: Build the application
+FROM maven:3.9-eclipse-temurin-21 AS builder
+
+WORKDIR /app
+
+# Install parent POMs
+COPY pom.xml .
+COPY infra/pom.xml ./infra/
+COPY infra/config-server/pom.xml ./infra/config-server/
+
+RUN mvn install -N
+RUN mvn install -N -f infra/pom.xml
+RUN mvn install -N -f infra/config-server/pom.xml
+
+# Build the server config application
+COPY infra/config-server ./infra/config-server
+RUN mvn -f /app/pom.xml package -DskipTests
+
+# Stage 2: Create image
+FROM eclipse-temurin:21-jre-jammy
+
+WORKDIR /app
+
+EXPOSE 8888
+
+COPY --from=builder /app/target/*.jar app.jar
+
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/infra/config-server/pom.xml
+++ b/infra/config-server/pom.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>ru.yandex.practicum</groupId>
+    <artifactId>smart-home-tech</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>config-server</artifactId>
+
+  <properties>
+    <maven.compiler.source>21</maven.compiler.source>
+    <maven.compiler.target>21</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.cloud</groupId>
+      <artifactId>spring-cloud-config-server</artifactId>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/infra/config-server/pom.xml
+++ b/infra/config-server/pom.xml
@@ -23,6 +23,19 @@
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-config-server</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
 
 </project>

--- a/infra/config-server/src/main/java/ru/yandex/practicum/smarthometech/ConfigServerApplication.java
+++ b/infra/config-server/src/main/java/ru/yandex/practicum/smarthometech/ConfigServerApplication.java
@@ -1,0 +1,15 @@
+package ru.yandex.practicum.smarthometech;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.config.server.EnableConfigServer;
+
+@EnableConfigServer
+@SpringBootApplication
+public class ConfigServerApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(ConfigServerApplication.class, args);
+    }
+
+}

--- a/infra/config-server/src/main/java/ru/yandex/practicum/smarthometech/configserver/ConfigServerApplication.java
+++ b/infra/config-server/src/main/java/ru/yandex/practicum/smarthometech/configserver/ConfigServerApplication.java
@@ -1,4 +1,4 @@
-package ru.yandex.practicum.smarthometech;
+package ru.yandex.practicum.smarthometech.configserver;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/infra/config-server/src/main/resources/application.yaml
+++ b/infra/config-server/src/main/resources/application.yaml
@@ -1,0 +1,14 @@
+server:
+  port: 8888
+
+spring:
+  application:
+    name: config-server
+  profiles:
+    active: native
+  cloud:
+    config:
+      server:
+        native:
+          searchLocations:
+            - classpath:config/telemetry/{application}

--- a/infra/config-server/src/main/resources/config/telemetry/aggregator/application-docker.yaml
+++ b/infra/config-server/src/main/resources/config/telemetry/aggregator/application-docker.yaml
@@ -1,0 +1,3 @@
+spring:
+  kafka:
+    bootstrap-servers: kafka:29092

--- a/infra/config-server/src/main/resources/config/telemetry/aggregator/application.yaml
+++ b/infra/config-server/src/main/resources/config/telemetry/aggregator/application.yaml
@@ -1,0 +1,20 @@
+spring:
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    consumer:
+      group-id: aggregator-group
+      auto-offset-reset: earliest
+      value-deserializer: ru.yandex.practicum.kafka.telemetry.deserializer.SensorEventDeserializer
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      properties:
+        fetch.min.bytes: 1
+        max.poll.records: 100
+        max.poll.interval.ms: 30000
+    producer:
+      value-serializer: ru.yandex.practicum.kafka.telemetry.serializer.SensorSnapshotSerializer
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+
+kafka:
+  topic:
+    sensors: telemetry.sensors.v1
+    snapshots: telemetry.snapshots.v1

--- a/infra/config-server/src/main/resources/config/telemetry/analyzer/application-docker.yaml
+++ b/infra/config-server/src/main/resources/config/telemetry/analyzer/application-docker.yaml
@@ -1,0 +1,7 @@
+spring:
+  kafka:
+    bootstrap-servers: kafka:29092
+  datasource:
+    url: jdbc:postgresql://postgres:5432/smart_home_tech
+    username: postgres
+    password: postgres

--- a/infra/config-server/src/main/resources/config/telemetry/analyzer/application.yaml
+++ b/infra/config-server/src/main/resources/config/telemetry/analyzer/application.yaml
@@ -1,0 +1,30 @@
+spring:
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    consumer:
+      group-id: aggregator-group
+      auto-offset-reset: earliest
+      properties:
+        fetch.min.bytes: 1
+        max.poll.records: 10
+        max.poll.interval.ms: 30000
+  datasource:
+    url: ${DATASOURCE_URL:jdbc:postgresql://localhost:5432/smart_home_tech}
+    username: ${DATASOURCE_USERNAME:postgres}
+    password: ${DATASOURCE_PASSWORD:postgres}
+  jpa:
+    hibernate:
+      ddl-auto: update
+
+kafka:
+  topic:
+    hubs: telemetry.hubs.v1
+    snapshots: telemetry.snapshots.v1
+
+grpc:
+  client:
+    hub-router:
+      address: 'static://localhost:59090'
+      enableKeepAlive: true
+      keepAliveWithoutCalls: true
+      negotiationType: plaintext

--- a/infra/config-server/src/main/resources/config/telemetry/collector/application-docker.yaml
+++ b/infra/config-server/src/main/resources/config/telemetry/collector/application-docker.yaml
@@ -1,0 +1,3 @@
+spring:
+  kafka:
+    bootstrap-servers: kafka:29092

--- a/infra/config-server/src/main/resources/config/telemetry/collector/application.yaml
+++ b/infra/config-server/src/main/resources/config/telemetry/collector/application.yaml
@@ -1,0 +1,15 @@
+spring:
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.ByteArraySerializer
+
+kafka:
+  topic:
+    sensors: telemetry.sensors.v1
+    hubs: telemetry.hubs.v1
+
+grpc:
+  server:
+    port: 9090

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
         <module>telemetry</module>
         <module>infra</module>
         <module>commerce</module>
+        <module>infra/config-server</module>
     </modules>
 
     <properties>
@@ -32,6 +33,7 @@
         <grpc.version>1.63.0</grpc.version>
         <mapstruct.version>1.6.3</mapstruct.version>
         <postgresql.version>42.7.7</postgresql.version>
+        <spring-cloud-dependencies.version>2025.0.0</spring-cloud-dependencies.version>
 
         <!--       Plugins       -->
         <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
@@ -69,6 +71,14 @@
                 <groupId>org.postgresql</groupId>
                 <artifactId>postgresql</artifactId>
                 <version>${postgresql.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-dependencies</artifactId>
+                <version>${spring-cloud-dependencies.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
 
             <!--    GRPC dependencies management        -->

--- a/telemetry/aggregator/Dockerfile
+++ b/telemetry/aggregator/Dockerfile
@@ -7,6 +7,7 @@ WORKDIR /app
 COPY pom.xml .
 COPY telemetry/pom.xml ./telemetry/
 COPY telemetry/serialization/pom.xml ./telemetry/serialization/
+COPY telemetry/telemetry-commons/pom.xml ./telemetry/telemetry-commons/
 
 RUN mvn install -N
 RUN mvn install -N -f telemetry/pom.xml
@@ -15,6 +16,13 @@ RUN mvn install -N -f telemetry/serialization/pom.xml
 # Install serialization dependencies
 COPY telemetry/serialization/avro-schemas ./telemetry/serialization/avro-schemas
 RUN mvn install -f telemetry/serialization/avro-schemas/pom.xml -DskipTests
+
+COPY telemetry/serialization/proto-schemas ./telemetry/serialization/proto-schemas
+RUN mvn install -f telemetry/serialization/proto-schemas/pom.xml -DskipTests
+
+# Install common dependencies
+COPY telemetry/telemetry-commons ./telemetry/telemetry-commons
+RUN mvn install -f telemetry/telemetry-commons/pom.xml -DskipTests
 
 # Build the aggregator application
 COPY telemetry/aggregator ./telemetry/aggregator

--- a/telemetry/aggregator/pom.xml
+++ b/telemetry/aggregator/pom.xml
@@ -14,50 +14,8 @@
   <dependencies>
     <dependency>
       <groupId>ru.yandex.practicum</groupId>
-      <artifactId>avro-schemas</artifactId>
+      <artifactId>telemetry-commons</artifactId>
       <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-validation</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.kafka</groupId>
-      <artifactId>spring-kafka</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.projectlombok</groupId>
-      <artifactId>lombok</artifactId>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
-      <groupId>org.mapstruct</groupId>
-      <artifactId>mapstruct</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.cloud</groupId>
-      <artifactId>spring-cloud-starter-config</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.retry</groupId>
-      <artifactId>spring-retry</artifactId>
-    </dependency>
-
-    <!-- Testing -->
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-test</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.kafka</groupId>
-      <artifactId>spring-kafka-test</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/telemetry/aggregator/pom.xml
+++ b/telemetry/aggregator/pom.xml
@@ -17,6 +17,28 @@
       <artifactId>telemetry-commons</artifactId>
       <version>${project.version}</version>
     </dependency>
+
+    <!-- Testing -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.kafka</groupId>
+      <artifactId>spring-kafka-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-server-common</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/telemetry/aggregator/pom.xml
+++ b/telemetry/aggregator/pom.xml
@@ -34,6 +34,14 @@
       <groupId>org.mapstruct</groupId>
       <artifactId>mapstruct</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.cloud</groupId>
+      <artifactId>spring-cloud-starter-config</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.retry</groupId>
+      <artifactId>spring-retry</artifactId>
+    </dependency>
 
     <!-- Testing -->
     <dependency>

--- a/telemetry/aggregator/src/main/resources/application.yaml
+++ b/telemetry/aggregator/src/main/resources/application.yaml
@@ -1,20 +1,11 @@
 spring:
-  kafka:
-    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
-    consumer:
-      group-id: aggregator-group
-      auto-offset-reset: earliest
-      value-deserializer: ru.yandex.practicum.kafka.telemetry.deserializer.SensorEventDeserializer
-      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
-      properties:
-        fetch.min.bytes: 1
-        max.poll.records: 100
-        max.poll.interval.ms: 30000
-    producer:
-      value-serializer: ru.yandex.practicum.kafka.telemetry.serializer.SensorSnapshotSerializer
-      key-serializer: org.apache.kafka.common.serialization.StringSerializer
-
-kafka:
-  topic:
-    sensors: telemetry.sensors.v1
-    snapshots: telemetry.snapshots.v1
+  application:
+    name: aggregator
+  config:
+    import: configserver:http://localhost:8888
+  cloud:
+    config:
+      fail-fast: true
+      retry:
+        useRandomPolicy: true
+        max-interval: 6000

--- a/telemetry/aggregator/src/main/resources/application.yaml
+++ b/telemetry/aggregator/src/main/resources/application.yaml
@@ -2,7 +2,7 @@ spring:
   application:
     name: aggregator
   config:
-    import: configserver:http://localhost:8888
+    import: ${SPRING_CONFIG_IMPORT:configserver:http://localhost:8888}
   cloud:
     config:
       fail-fast: true

--- a/telemetry/analyzer/Dockerfile
+++ b/telemetry/analyzer/Dockerfile
@@ -7,6 +7,7 @@ WORKDIR /app
 COPY pom.xml .
 COPY telemetry/pom.xml ./telemetry/
 COPY telemetry/serialization/pom.xml ./telemetry/serialization/
+COPY telemetry/telemetry-commons/pom.xml ./telemetry/telemetry-commons/
 
 RUN mvn install -N
 RUN mvn install -N -f telemetry/pom.xml
@@ -18,6 +19,10 @@ RUN mvn install -f telemetry/serialization/avro-schemas/pom.xml -DskipTests
 
 COPY telemetry/serialization/proto-schemas ./telemetry/serialization/proto-schemas
 RUN mvn install -f telemetry/serialization/proto-schemas/pom.xml -DskipTests
+
+# Install common dependencies
+COPY telemetry/telemetry-commons ./telemetry/telemetry-commons
+RUN mvn install -f telemetry/telemetry-commons/pom.xml -DskipTests
 
 # Build the analyzer application
 COPY telemetry/analyzer ./telemetry/analyzer

--- a/telemetry/analyzer/pom.xml
+++ b/telemetry/analyzer/pom.xml
@@ -33,6 +33,21 @@
 
     <!-- Testing -->
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.kafka</groupId>
+      <artifactId>spring-kafka-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-server-common</artifactId>
       <scope>test</scope>

--- a/telemetry/analyzer/pom.xml
+++ b/telemetry/analyzer/pom.xml
@@ -14,26 +14,8 @@
   <dependencies>
     <dependency>
       <groupId>ru.yandex.practicum</groupId>
-      <artifactId>avro-schemas</artifactId>
+      <artifactId>telemetry-commons</artifactId>
       <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>ru.yandex.practicum</groupId>
-      <artifactId>proto-schemas</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-validation</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.kafka</groupId>
-      <artifactId>spring-kafka</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.projectlombok</groupId>
-      <artifactId>lombok</artifactId>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>net.devh</groupId>
@@ -48,35 +30,8 @@
       <artifactId>postgresql</artifactId>
       <version>42.7.4</version>
     </dependency>
-    <dependency>
-      <groupId>org.mapstruct</groupId>
-      <artifactId>mapstruct</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.cloud</groupId>
-      <artifactId>spring-cloud-starter-config</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.retry</groupId>
-      <artifactId>spring-retry</artifactId>
-    </dependency>
 
     <!-- Testing -->
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-test</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.kafka</groupId>
-      <artifactId>spring-kafka-test</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-server-common</artifactId>

--- a/telemetry/analyzer/pom.xml
+++ b/telemetry/analyzer/pom.xml
@@ -52,6 +52,14 @@
       <groupId>org.mapstruct</groupId>
       <artifactId>mapstruct</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.cloud</groupId>
+      <artifactId>spring-cloud-starter-config</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.retry</groupId>
+      <artifactId>spring-retry</artifactId>
+    </dependency>
 
     <!-- Testing -->
     <dependency>

--- a/telemetry/analyzer/src/main/resources/application.yaml
+++ b/telemetry/analyzer/src/main/resources/application.yaml
@@ -2,7 +2,7 @@ spring:
   application:
     name: analyzer
   config:
-    import: configserver:http://localhost:8888
+    import: ${SPRING_CONFIG_IMPORT:configserver:http://localhost:8888}
   cloud:
     config:
       fail-fast: true

--- a/telemetry/analyzer/src/main/resources/application.yaml
+++ b/telemetry/analyzer/src/main/resources/application.yaml
@@ -1,30 +1,11 @@
 spring:
-  kafka:
-    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
-    consumer:
-      group-id: aggregator-group
-      auto-offset-reset: earliest
-      properties:
-        fetch.min.bytes: 1
-        max.poll.records: 10
-        max.poll.interval.ms: 30000
-  datasource:
-    url: ${DATASOURCE_URL:jdbc:postgresql://localhost:5432/smart_home_tech}
-    username: ${DATASOURCE_USERNAME:postgres}
-    password: ${DATASOURCE_PASSWORD:postgres}
-  jpa:
-    hibernate:
-      ddl-auto: update
-
-kafka:
-  topic:
-    hubs: telemetry.hubs.v1
-    snapshots: telemetry.snapshots.v1
-
-grpc:
-  client:
-    hub-router:
-      address: 'static://localhost:59090'
-      enableKeepAlive: true
-      keepAliveWithoutCalls: true
-      negotiationType: plaintext
+  application:
+    name: analyzer
+  config:
+    import: configserver:http://localhost:8888
+  cloud:
+    config:
+      fail-fast: true
+      retry:
+        useRandomPolicy: true
+        max-interval: 6000

--- a/telemetry/collector/Dockerfile
+++ b/telemetry/collector/Dockerfile
@@ -7,6 +7,7 @@ WORKDIR /app
 COPY pom.xml .
 COPY telemetry/pom.xml ./telemetry/
 COPY telemetry/serialization/pom.xml ./telemetry/serialization/
+COPY telemetry/telemetry-commons/pom.xml ./telemetry/telemetry-commons/
 
 RUN mvn install -N
 RUN mvn install -N -f telemetry/pom.xml
@@ -18,6 +19,10 @@ RUN mvn install -f telemetry/serialization/avro-schemas/pom.xml -DskipTests
 
 COPY telemetry/serialization/proto-schemas ./telemetry/serialization/proto-schemas
 RUN mvn install -f telemetry/serialization/proto-schemas/pom.xml -DskipTests
+
+# Install common dependencies
+COPY telemetry/telemetry-commons ./telemetry/telemetry-commons
+RUN mvn install -f telemetry/telemetry-commons/pom.xml -DskipTests
 
 # Build the collector application
 COPY telemetry/collector ./telemetry/collector

--- a/telemetry/collector/pom.xml
+++ b/telemetry/collector/pom.xml
@@ -21,6 +21,28 @@
             <groupId>net.devh</groupId>
             <artifactId>grpc-server-spring-boot-starter</artifactId>
         </dependency>
+
+        <!-- Testing -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-server-common</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/telemetry/collector/pom.xml
+++ b/telemetry/collector/pom.xml
@@ -43,6 +43,14 @@
             <groupId>org.mapstruct</groupId>
             <artifactId>mapstruct</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-config</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.retry</groupId>
+            <artifactId>spring-retry</artifactId>
+        </dependency>
 
         <!-- Testing -->
         <dependency>

--- a/telemetry/collector/pom.xml
+++ b/telemetry/collector/pom.xml
@@ -14,59 +14,12 @@
     <dependencies>
         <dependency>
             <groupId>ru.yandex.practicum</groupId>
-            <artifactId>avro-schemas</artifactId>
+            <artifactId>telemetry-commons</artifactId>
             <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>ru.yandex.practicum</groupId>
-            <artifactId>proto-schemas</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-validation</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.kafka</groupId>
-            <artifactId>spring-kafka</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>net.devh</groupId>
             <artifactId>grpc-server-spring-boot-starter</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.mapstruct</groupId>
-            <artifactId>mapstruct</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-starter-config</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.retry</groupId>
-            <artifactId>spring-retry</artifactId>
-        </dependency>
-
-        <!-- Testing -->
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.kafka</groupId>
-            <artifactId>spring-kafka-test</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/telemetry/collector/src/main/resources/application.yaml
+++ b/telemetry/collector/src/main/resources/application.yaml
@@ -1,15 +1,11 @@
 spring:
-  kafka:
-    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
-    producer:
-      key-serializer: org.apache.kafka.common.serialization.StringSerializer
-      value-serializer: org.apache.kafka.common.serialization.ByteArraySerializer
-
-kafka:
-  topic:
-    sensors: telemetry.sensors.v1
-    hubs: telemetry.hubs.v1
-
-grpc:
-  server:
-    port: 9090
+  application:
+    name: collector
+  config:
+    import: configserver:http://localhost:8888
+  cloud:
+    config:
+      fail-fast: true
+      retry:
+        useRandomPolicy: true
+        max-interval: 6000

--- a/telemetry/collector/src/main/resources/application.yaml
+++ b/telemetry/collector/src/main/resources/application.yaml
@@ -2,7 +2,7 @@ spring:
   application:
     name: collector
   config:
-    import: configserver:http://localhost:8888
+    import: ${SPRING_CONFIG_IMPORT:configserver:http://localhost:8888}
   cloud:
     config:
       fail-fast: true

--- a/telemetry/pom.xml
+++ b/telemetry/pom.xml
@@ -17,6 +17,7 @@
         <module>collector</module>
         <module>aggregator</module>
       <module>analyzer</module>
+      <module>telemetry-commons</module>
     </modules>
 
 </project>

--- a/telemetry/telemetry-commons/pom.xml
+++ b/telemetry/telemetry-commons/pom.xml
@@ -52,23 +52,6 @@
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
     </dependency>
-
-    <!-- Testing -->
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-test</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.kafka</groupId>
-      <artifactId>spring-kafka-test</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
 </project>

--- a/telemetry/telemetry-commons/pom.xml
+++ b/telemetry/telemetry-commons/pom.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>ru.yandex.practicum</groupId>
+    <artifactId>telemetry</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>telemetry-commons</artifactId>
+
+  <properties>
+    <maven.compiler.source>21</maven.compiler.source>
+    <maven.compiler.target>21</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>ru.yandex.practicum</groupId>
+      <artifactId>avro-schemas</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>ru.yandex.practicum</groupId>
+      <artifactId>proto-schemas</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-validation</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.kafka</groupId>
+      <artifactId>spring-kafka</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.cloud</groupId>
+      <artifactId>spring-cloud-starter-config</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.retry</groupId>
+      <artifactId>spring-retry</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.mapstruct</groupId>
+      <artifactId>mapstruct</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+    </dependency>
+
+    <!-- Testing -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.kafka</groupId>
+      <artifactId>spring-kafka-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>


### PR DESCRIPTION
Выполнен рефакторинг для централизации конфигурации сервисов и упрощения управления зависимостями. Изменения направлены на повышение поддерживаемости и снижение дублирования кода.

#### 1. Централизация конфигурации через Spring Cloud Config

*   Вся конфигурация сервисов (`analyzer`, `aggregator`, `collector`) **перенесена** из локальных файлов `application.yaml` на **Spring Cloud Config Server**.
*   Это **упрощает управление** свойствами приложений (например, адресами Kafka, настройками БД) и позволяет изменять их без пересборки сервисов.
*   Каждый сервис теперь содержит минимальную `bootstrap`-конфигурацию, указывающую на расположение Config Server.

#### 2. Вынесение общих зависимостей в модуль `telemetry-commons`

*   Для устранения дублирования кода в POM-файлах создан новый общий модуль `telemetry-commons`.
*   В него **вынесены** все пересекающиеся зависимости, используемые в сервисах `analyzer`, `aggregator` и `collector` (включая Spring Cloud, Kafka, gRPC, Lombok, MapStruct).
*   Теперь для подключения всего набора общих библиотек достаточно **добавить одну зависимость** на `telemetry-commons`, что делает POM-файлы сервисов значительно чище.